### PR TITLE
feat(ModelFolder): expose model folder name.

### DIFF
--- a/honeybee_radiance_folder/folder.py
+++ b/honeybee_radiance_folder/folder.py
@@ -163,6 +163,19 @@ class ModelFolder(_Folder):
         self._aperture_groups_load = True  # boolean to keep track of first load
         self._dynamic_scene_load = True  # boolean to keep track of first load
 
+    @classmethod
+    def from_model_folder(cls, model_folder, config_file=None):
+        """Use model folder instead of project folder.
+
+        Args:
+            model_folder (str): Model folder as string. The folder will be created on
+            write if it doesn't exist already.
+        config_file (str): Optional config file to modify the default folder names. By
+            default ``folder.cfg`` in ``honeybee-radiance-folder`` will be used.
+        """
+        project_folder, folder_name = os.path.split(model_folder)
+        return cls(project_folder, folder_name, config_file)
+
     def model_folder(self, full=False):
         """Model root folder.
 

--- a/tests/folder_test.py
+++ b/tests/folder_test.py
@@ -31,6 +31,32 @@ def test_writer():
     shutil.rmtree(folder_path, ignore_errors=True)
 
 
+def test_writer_model_folder():
+    """Test creating a new folder."""
+    folder_path = r'./tests/assets/temp/rad_model'
+    shutil.rmtree(folder_path, ignore_errors=True)
+    rad_folder = Folder.from_model_folder(folder_path)
+    rad_folder.write(folder_type=2, overwrite=True)
+
+    assert os.path.isdir(rad_folder.folder)
+    root_folder = rad_folder.model_folder(full=True)
+    assert os.path.isdir(root_folder)
+    subfolders = [
+        f for f in os.listdir(root_folder)
+        if os.path.isdir(os.path.join(root_folder, f))
+    ]
+
+    cfg_names = ['GRID', 'VIEW'] + [k for k, v in config.minimal.items() if v is True]
+    expected_subfolders = [rad_folder._get_folder_name(f) for f in cfg_names]
+
+    assert len(subfolders) == len(expected_subfolders)
+    for f in expected_subfolders:
+        assert f in subfolders
+
+    # try to remove the folder
+    shutil.rmtree(folder_path, ignore_errors=True)
+
+
 def test_reader():
     radiance_folder = r'./tests/assets/project_folder'
     rad_folder = Folder(radiance_folder)


### PR DESCRIPTION
Added a classmethod to allow initiating the ModelFolder class using the path to model folder itself instead of project folder. This is especially useful to read a folder which already has been created.