### PR TITLE
fix(folderutil): Fixed a path-related bug in folderutil

### DIFF
--- a/honeybee_radiance_folder/folderutil.py
+++ b/honeybee_radiance_folder/folderutil.py
@@ -92,10 +92,10 @@ class ApertureState(SceneState):
         self, identifier, default, direct, black=None, tmtx=None, vmtx=None,
             dmtx=None):
         SceneState.__init__(self, identifier, default, direct)
-        self.black = _as_posix(black)
-        self.tmtx = _as_posix(tmtx)
-        self.vmtx = _as_posix(vmtx)
-        self.dmtx = _as_posix(dmtx)
+        self.black = _as_posix(black) if black is not None else None
+        self.tmtx = _as_posix(tmtx) if tmtx is not None else None
+        self.vmtx = _as_posix(vmtx) if vmtx is not None else None
+        self.dmtx = _as_posix(dmtx) if dmtx is not None else None
 
     @classmethod
     def from_dict(cls, input_dict):


### PR DESCRIPTION
@chriswmackey and @mostaphaRoudsari . 
I get this error ..
![image](https://user-images.githubusercontent.com/91887472/141462770-46f4e4bc-7248-44de-9f19-e6b9f551ce2d.png)
..when I trying to query the aperturegroups in the radiance folder.
![a](https://user-images.githubusercontent.com/91887472/141462366-0283b100-6106-47f4-a6ed-bf2c7791bbc0.png)

The culprit is this: 
![b](https://user-images.githubusercontent.com/91887472/141462404-58402fb0-3589-4b79-bf0a-9daa0888083f.png)
(It tries to replace slashes in path even when the input is None. I guess None is the default option, because for cases like the one highlighted below there wont be any t,d,v etc. matrices).
![c](https://user-images.githubusercontent.com/91887472/141462466-0743d13b-32de-4d99-8f8c-17d2e85c1a0b.png)

The fix applied was to just check if the path is None or not.
