### PR TITLE
perf(combined-receiver): Return the paths of the combined receivers

### DIFF
--- a/honeybee_radiance_folder/folder.py
+++ b/honeybee_radiance_folder/folder.py
@@ -526,6 +526,8 @@ class ModelFolder(_Folder):
         if not os.path.isdir(folder):
             os.mkdir(folder)
 
+        receiver_list = []
+
         # find the light_path for each grid
         for grid in grids.values():
             light_path = grid['light_path']
@@ -535,12 +537,16 @@ class ModelFolder(_Folder):
                 p[0] for p in light_path if p[0] in states and 'vmtx' in states[p[0]][0]
             ]
             # write combined receiver for grid
-            combined_receiver(
+            receiver_file = combined_receiver(
                 grid['identifier'],
                 apt_group_folder,
                 aperture_groups,
                 folder
             )
+
+            receiver_list.append(receiver_file)
+
+        return receiver_list
 
     def dynamic_scene(self, indoor=False, reload=False):
         """List of dynamic non-aperture geometries.

--- a/honeybee_radiance_folder/folderutil.py
+++ b/honeybee_radiance_folder/folderutil.py
@@ -430,11 +430,12 @@ def combined_receiver(grid_name, apt_group_folder, apt_groups, target_folder):
     for apt in apt_groups:
         content.append('#@rfluxmtx o=%s..%s.vmx' % (apt, grid_name))
         content.append('!xform ./%s/%s..mtx.rad\n' % (apt_group_folder, apt))
-    
+
     out_file = os.path.join(target_folder, file_name)
     with open(out_file, 'w') as outf:
         outf.write('\n'.join(content))
 
+    return out_file
 
 def _nukedir(target_dir, rmdir=True):
     """Delete all the files inside target_dir.


### PR DESCRIPTION
Right now the functions that write out the combined receivers do not return the file paths that are written out. Having access to these paths will be useful in managing the matrix creation process.

Resolves https://github.com/ladybug-tools/honeybee-radiance-folder/issues/119