### PR TITLE
perf(combined-receiver-output): Allow the auto vmtx path to be optional

### DIFF
--- a/honeybee_radiance_folder/folder.py
+++ b/honeybee_radiance_folder/folder.py
@@ -504,7 +504,7 @@ class ModelFolder(_Folder):
                 apt_group_folder, self._config['APERTURE-GROUP']['states'])
         return parse_states(states_file)
 
-    def combined_receivers(self, folder='receivers'):
+    def combined_receivers(self, folder='receivers', auto_mtx_path=True):
         """Write combined receiver files to folder.
 
         This function writes a combined receiver file of the aperture groups for all
@@ -517,6 +517,8 @@ class ModelFolder(_Folder):
 
         Arg:
             folder: A path of the target folder to write files to (default: 'receivers').
+            auto_mtx_path: If set to True, then the path of the view matrices will be
+                specified automatically.
         """
         grids = self.grid_data_all()
         apt_group_folder = self.aperture_group_folder(full=False)
@@ -541,8 +543,7 @@ class ModelFolder(_Folder):
                 grid['identifier'],
                 apt_group_folder,
                 aperture_groups,
-                folder
-            )
+                folder, add_output_header=auto_mtx_path)
 
             receiver_list.append(receiver_file)
 

--- a/honeybee_radiance_folder/folderutil.py
+++ b/honeybee_radiance_folder/folderutil.py
@@ -411,7 +411,8 @@ def parse_states(states_file):
         return json.load(inf)
 
 
-def combined_receiver(grid_name, apt_group_folder, apt_groups, target_folder):
+def combined_receiver(grid_name, apt_group_folder, apt_groups, target_folder,
+                      add_output_header=True):
     """Write combined receiver file for a grid and aperture groups.
 
     The aperture group folder must be a relative path. Otherwise xform will fail when
@@ -422,13 +423,16 @@ def combined_receiver(grid_name, apt_group_folder, apt_groups, target_folder):
         apt_group_folder: Path to aperture group folder.
         apt_groups: A list of aperture groups to include in the combined receiver.
         target_folder: A path of the target folder to write files to.
+        add_output_header: If set to True, a header will be added to redirect the
+            generated view matrix to the path specified through the "o= .." option.
     """
     file_name = '%s..receiver.rad' % grid_name
     apt_group_folder = apt_group_folder.replace('\\', '/')
     content = []
     content.append('# %s\n' % file_name)  # add header
     for apt in apt_groups:
-        content.append('#@rfluxmtx o=%s..%s.vmx' % (apt, grid_name))
+        if add_output_header:
+            content.append('#@rfluxmtx o=%s..%s.vmx' % (apt, grid_name))
         content.append('!xform ./%s/%s..mtx.rad\n' % (apt_group_folder, apt))
 
     out_file = os.path.join(target_folder, file_name)


### PR DESCRIPTION
The combined receiver functionality that exists is pretty handy. However, the redirecting of view matrix paths automatically is a problem. 

The issues are several: firstly, the "o=%s..%s.vmx" does not allow any flexibility in where the view matrix would written to and writing to the root directory itself will lead to confusion for large projects with several view matrices littering the root folder. 

Secondly, this way of generating view matrices is somewhat of a black box as one as to write additional logic to locate the view matrices that were generated automatically. So, I am allowing an opt-out feature such that the view matrices are not automatically redirected (if one chooses to do so).